### PR TITLE
feat: multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM golang:1.18
-RUN mkdir /app
-ADD . /app
-WORKDIR /app
-RUN go build -o main .
-CMD ["/app/main"]
+FROM golang:1.18 as builder
+RUN mkdir /build
+ADD . /build
+WORKDIR /build
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+#RUN apk update && apk add libc6-compat
+WORKDIR /app/
+RUN mkdir -p ./static/css ./templates
+COPY --from=builder /build/main ./
+COPY --from=builder /build/static/css/ ./static/css/
+COPY --from=builder /build/templates/ ./templates/
+CMD ["./main"]


### PR DESCRIPTION
This implements #23 

Everything still work the same, except the final docker image is now less than 25mb, compared to 1gb before.

For more detail see https://docs.docker.com/build/building/multi-stage/
