### PR TITLE
feat: get and view data of a given table with pagination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,12 @@ require (
 	github.com/gofiber/template v1.7.1
 	github.com/mattn/go-sqlite3 v1.14.15
 )
+
+require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/klauspost/compress v1.15.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.40.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,3 @@ require (
 	github.com/gofiber/template v1.7.1
 	github.com/mattn/go-sqlite3 v1.14.15
 )
-
-require (
-	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/klauspost/compress v1.15.0 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.40.0 // indirect
-	github.com/valyala/tcplisten v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
-)

--- a/routes/handlers.go
+++ b/routes/handlers.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"log"
 	"fmt"
+	"log"
+	"strconv"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/shivansh-yadav13/sqlite-web/db"
@@ -29,6 +30,19 @@ func Table(c *fiber.Ctx) error {
 	return c.Render("table_view", fiber.Map{
 		"table_name": c.Params("table"),
 		"sql_query":  query,
+	})
+}
+
+func TableData(c *fiber.Ctx) error {
+	page, _ := strconv.Atoi(c.Query("page"))
+	if page == 0 {
+		page = 1
+	}
+	cols, rows, _ := db.GetData(c.Params("table"), 10, (page-1)*10)
+	return c.Render("table_data_view", fiber.Map{
+		"table_name": c.Params("table"),
+		"columns":    cols,
+		"rows":       rows,
 	})
 }
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -11,7 +11,8 @@ func SetRoutes(app *fiber.App) {
 	// template routes
 
 	app.Get("/", Index)
-	app.Get("/:table", Table)
+	app.Get("/:table/schema", Table)
+	app.Get("/:table/data", TableData)
 
 	// database ops routes
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,10 @@
                     <div class="table-btns">
                         <button type="submit" class="table-btn">Drop table</button>
                         <button class="table-btn">
-                            <a href="/{{.}}">View table</a>
+                            <a href="/{{.}}/schema">Edit Schema</a>
+                        </button>
+                        <button class="table-btn">
+                            <a href="/{{.}}/data">View Data</a>
                         </button>
                     </div>
                 </form>

--- a/templates/table_data_view.html
+++ b/templates/table_data_view.html
@@ -1,0 +1,15 @@
+<table border="1">
+    <tr>
+    {{ range $col := .columns }}
+        <th>{{$col}}</th>
+    {{ end }}
+    </tr>
+
+    {{ range $row := .rows }}
+    <tr>
+        {{ range $cell := $row }}
+            <td>{{$cell}}</td>
+        {{ end }}
+    </tr>
+    {{ end }}
+</table>


### PR DESCRIPTION
This implements #27 

<img width="466" alt="Screen Shot 2022-10-18 at 11 47 09 AM" src="https://user-images.githubusercontent.com/803646/196480060-4510a894-db04-43cb-bda9-72c4e8166fd0.png">

A few notes:
- For sake of simplicity, if a field contains a long text, it's trimmed to the first 50 characters. This number can probably go up higher.
- Did not handle the case if a table has large number of columns, that may or may not be a big issue, but if not handled, next step is to at least update the ux to maybe improve the layout so all columns are not squashed together.
- Pagination is in place, although the UX element is needed, for now you could go to the next page by appending the query string `?page=2` 